### PR TITLE
Extending the mongo document design

### DIFF
--- a/services/back-end/main.ts
+++ b/services/back-end/main.ts
@@ -34,7 +34,10 @@ export default class Main {
       const kittySchema = new mongoose.Schema({
         name: String,
       });
-      const Kitten = mongoose.model('Kitten', kittySchema);
+      interface kitty extends mongoose.Document {
+        name: String 
+  	  }
+      const Kitten = mongoose.model<kitty>('Kitten', kittySchema);
       
       // write to db
       setInterval(async () => {


### PR DESCRIPTION
Fix for error TS2339: Property 'name' does not exist on type 'Document<any, any, any>'.